### PR TITLE
Fixes pg_service path in the example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,10 @@ FRONTEND=False
 
 # QGIS Server env variables
 # ----------------------------------------------------
-PGSERVICEFILE=/pg_service/pg_service.conf
-# Put your pg service into ./scripts/pg_service.conf file, the conf file will be mounted into
+
+# Put your pg service into ./secrets/pg_service.conf file, the conf file will be mounted into
 # docker container at runtime a the PGSERVICEFILE
+PGSERVICEFILE=/pg_service/pg_service.conf
 
 QGIS_SERVER_LOG_FILE=/shared_volume/QGIS/error.log
 QGIS_SERVER_LOG_LEVEL=2


### PR DESCRIPTION
Changes the path in the comment from `./scripts/pg_service.conf` to `./secrets/pg_service.conf`.

Also the comment is move before the variable as it is more readable.